### PR TITLE
Restore all methods to current nodes

### DIFF
--- a/audio-classifier/lib.js
+++ b/audio-classifier/lib.js
@@ -82,6 +82,30 @@ var ModelAssetExchangeServer = (function(){
         });
     };
 
+
+/**
+ * Return the metadata associated with the model
+ * @method
+ * @name ModelAssetExchangeServer#get_metadata
+ * @param {object} parameters - method options and parameters
+ */
+ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
+    if(parameters === undefined) {
+        parameters = {};
+    }
+    var deferred = Q.defer();
+    var domain = this.domain,  path = '/model/metadata';
+    var body = {}, queryParameters = {}, headers = {}, form = {};
+
+        headers['Accept'] = ['application/json'];
+        headers['Content-Type'] = ['application/json'];
+
+    queryParameters = mergeQueryParams(parameters, queryParameters);
+
+    this.request('GET', domain + path, parameters, body, headers, queryParameters, form, deferred);
+
+    return deferred.promise;
+ };
 /**
  * Predict audio classes from input data
  * @method

--- a/audio-classifier/locales/de-DE/node.json
+++ b/audio-classifier/locales/de-DE/node.json
@@ -12,7 +12,7 @@
             "requesting": "Anfrage..."
         },
         "parameters": {
-            "get_metadata": "get_metadata",
+            "get_metadata": "metadata",
             "predict": "predict",
             "audio": "audio",
             "optionalParameters": "Optionen"

--- a/audio-classifier/locales/en-US/node.json
+++ b/audio-classifier/locales/en-US/node.json
@@ -12,7 +12,7 @@
             "requesting": "requesting"
         },
         "parameters": {
-            "get_metadata": "get_metadata",
+            "get_metadata": "metadata",
             "predict": "predict",
             "audio": "audio",
             "optionalParameters": "Options"

--- a/audio-classifier/locales/ja/node.json
+++ b/audio-classifier/locales/ja/node.json
@@ -12,7 +12,7 @@
             "requesting": "要求中"
         },
         "parameters": {
-            "get_metadata": "get_metadata",
+            "get_metadata": "metadata",
             "predict": "predict",
             "audio": "audio",
             "optionalParameters": "任意項目"

--- a/audio-classifier/locales/zh-CN/node.json
+++ b/audio-classifier/locales/zh-CN/node.json
@@ -12,7 +12,7 @@
             "requesting": "请求中"
         },
         "parameters": {
-            "get_metadata": "get_metadata",
+            "get_metadata": "metadata",
             "predict": "predict",
             "audio": "audio",
             "optionalParameters": "可选项"

--- a/audio-classifier/node.html
+++ b/audio-classifier/node.html
@@ -122,7 +122,7 @@
         <dd>Prediction.</dd>
     </dl>
     <br>
-    <h1>get_metadata</h1>
+    <h1>metadata</h1>
     <h3>Inputs:</h3>
     <dl class="message-properties">
         <dt>none <span class="property-type">none</span></dt>

--- a/audio-classifier/node.js
+++ b/audio-classifier/node.js
@@ -13,38 +13,87 @@ module.exports = function (RED) {
         var node = this;
 
         node.on('input', function (msg) {
-            var client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
-
-
-            client.body = msg.payload;
-
-            var result;
             var errorFlag = false;
-            if (node.method === 'get_metadata') {
-                var parameters = [], nodeParam, nodeParamType;
-
-                result = client.get_metadata(parameters);
-            }
-            if (node.method === 'predict') {
-                var parameters = [], nodeParam, nodeParamType;
-
-                nodeParam = node.predict_audio;
-                nodeParamType = node.predict_audioType;
-                parameters.audio = msg.payload;
-                
-                result = client.predict(parameters);
+            var client;
+            if (this.service && this.service.host) {
+                client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
+            } else {
+                node.error('Host in configuration node is not specified.', msg);
+                errorFlag = true;
             }
             if (!errorFlag) {
-                node.status({ fill: "blue", shape: "dot", text: "ModelAssetExchangeServer.status.requesting" });
-                result.then(function (response) {
-                    if (response.body !== null && response.body !== undefined) {
-                        msg.payload = response.body.predictions[0].label || "Detection Error";
+                client.body = msg.payload;
+            }
+
+            var result;
+            if (!errorFlag && node.method === 'get_metadata') {
+                var get_metadata_parameters = [];
+                var get_metadata_nodeParam;
+                var get_metadata_nodeParamType;
+                result = client.get_metadata(get_metadata_parameters);
+            }
+            if (!errorFlag && node.method === 'predict') {
+                var predict_parameters = [];
+                var predict_nodeParam;
+                var predict_nodeParamType;
+
+                if (typeof msg.payload === 'object') {
+                    predict_parameters.body = msg.payload;
+                } else {
+                    node.error('Unsupported type: \'' + (typeof msg.payload) + '\', ' + 'msg.payload must be JSON object or buffer.', msg);
+                    errorFlag = true;
+                }
+                                result = client.predict(predict_parameters);
+            }
+            if (!errorFlag && result === undefined) {
+                node.error('Method is not specified.', msg);
+                errorFlag = true;
+            }
+            var setData = function (msg, data) {
+                if (data) {
+                    if (data.response) {
+                        if (data.response.statusCode) {
+                            msg.statusCode = data.response.statusCode;
+                        }
+                        if (data.response.headers) {
+                            msg.headers = data.response.headers;
+                        }
+                        if (data.response.request && data.response.request.uri && data.response.request.uri.href) {
+                            msg.responseUrl = data.response.request.uri.href;
+                        }
                     }
-                    node.send(msg);
+                    if (data.body) {
+                        if (node.method === 'get_metadata') {
+                            msg.payload = data.body;
+                        }
+                        if (node.method === 'predict') {
+                            if (data.body.predictions && data.body.predictions.length > 0) {
+                                msg.payload = data.body.predictions[0].caption;
+                            } else {
+                                msg.payload = null;
+                            }
+                        }
+                        msg.details = data.body;
+                    }
+                }
+                return msg;
+            };
+            if (!errorFlag) {
+                node.status({ fill: 'blue', shape: 'dot', text: 'ModelAssetExchangeServer.status.requesting' });
+                result.then(function (data) {
+                    node.send(setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
-                    node.error(error, msg);
-                    node.status({ fill: "red", shape: "ring", text: "node-red:common.status.error" });
+                    var message = null;
+                    if (error && error.body) {
+                        if (error.body.message) {
+                            message = error.body.message;
+                        } else {
+                            message = error.body;
+                        }
+                    }
+                    node.error(message, setData(msg, error));
+                    node.status({ fill: 'red', shape: 'ring', text: 'node-red:common.status.error' });
                 });
             }
         });

--- a/audio-classifier/node.js
+++ b/audio-classifier/node.js
@@ -13,87 +13,44 @@ module.exports = function (RED) {
         var node = this;
 
         node.on('input', function (msg) {
-            var errorFlag = false;
-            var client;
-            if (this.service && this.service.host) {
-                client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
-            } else {
-                node.error('Host in configuration node is not specified.', msg);
-                errorFlag = true;
-            }
-            if (!errorFlag) {
-                client.body = msg.payload;
-            }
+            var client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
+
+
+            client.body = msg.payload;
 
             var result;
-            if (!errorFlag && node.method === 'get_metadata') {
-                var get_metadata_parameters = [];
-                var get_metadata_nodeParam;
-                var get_metadata_nodeParamType;
-                result = client.get_metadata(get_metadata_parameters);
-            }
-            if (!errorFlag && node.method === 'predict') {
-                var predict_parameters = [];
-                var predict_nodeParam;
-                var predict_nodeParamType;
+            var errorFlag = false;
+            if (node.method === 'get_metadata') {
+                var parameters = [], nodeParam, nodeParamType;
 
-                if (typeof msg.payload === 'object') {
-                    predict_parameters.body = msg.payload;
-                } else {
-                    node.error('Unsupported type: \'' + (typeof msg.payload) + '\', ' + 'msg.payload must be JSON object or buffer.', msg);
-                    errorFlag = true;
-                }
-                                result = client.predict(predict_parameters);
+                result = client.get_metadata(parameters);
             }
-            if (!errorFlag && result === undefined) {
-                node.error('Method is not specified.', msg);
-                errorFlag = true;
+            
+            if (node.method === 'predict') {
+                var parameters = [], nodeParam, nodeParamType;
+
+                nodeParam = node.predict_audio;
+                nodeParamType = node.predict_audioType;
+                parameters.audio = msg.payload; 
+                
+                result = client.predict(parameters);
             }
-            var setData = function (msg, data) {
-                if (data) {
-                    if (data.response) {
-                        if (data.response.statusCode) {
-                            msg.statusCode = data.response.statusCode;
-                        }
-                        if (data.response.headers) {
-                            msg.headers = data.response.headers;
-                        }
-                        if (data.response.request && data.response.request.uri && data.response.request.uri.href) {
-                            msg.responseUrl = data.response.request.uri.href;
-                        }
-                    }
-                    if (data.body) {
-                        if (node.method === 'get_metadata') {
-                            msg.payload = data.body;
-                        }
-                        if (node.method === 'predict') {
-                            if (data.body.predictions && data.body.predictions.length > 0) {
-                                msg.payload = data.body.predictions[0].caption;
-                            } else {
-                                msg.payload = null;
-                            }
-                        }
-                        msg.details = data.body;
-                    }
-                }
-                return msg;
-            };
+            
             if (!errorFlag) {
-                node.status({ fill: 'blue', shape: 'dot', text: 'ModelAssetExchangeServer.status.requesting' });
-                result.then(function (data) {
-                    node.send(setData(msg, data));
+                node.status({ fill: "blue", shape: "dot", text: "ModelAssetExchangeServer.status.requesting" });
+                result.then(function (response) {
+                    if (node.method === 'get_metadata') {
+                        msg.payload = response.body;
+                    }
+
+                    if (node.method === 'predict' && response.body !== null && response.body !== undefined) {
+                        msg.payload = response.body.predictions[0].label || "Detection Error";
+                    }
+                    node.send(msg);
                     node.status({});
                 }).catch(function (error) {
-                    var message = null;
-                    if (error && error.body) {
-                        if (error.body.message) {
-                            message = error.body.message;
-                        } else {
-                            message = error.body;
-                        }
-                    }
-                    node.error(message, setData(msg, error));
-                    node.status({ fill: 'red', shape: 'ring', text: 'node-red:common.status.error' });
+                    node.error(error, msg);
+                    node.status({ fill: "red", shape: "ring", text: "node-red:common.status.error" });
                 });
             }
         });

--- a/audio-classifier/node.js
+++ b/audio-classifier/node.js
@@ -63,7 +63,7 @@ module.exports = function (RED) {
                         } else {
                             msg.payload = null;
                         }
-                        msg.details = data.body;
+                        msg.details = response.body;
                     }
                     
                     node.send(msg);

--- a/audio-classifier/node.js
+++ b/audio-classifier/node.js
@@ -63,6 +63,7 @@ module.exports = function (RED) {
                         } else {
                             msg.payload = null;
                         }
+                        msg.details = data.body;
                     }
                     
                     node.send(msg);

--- a/audio-classifier/node.js
+++ b/audio-classifier/node.js
@@ -13,39 +13,58 @@ module.exports = function (RED) {
         var node = this;
 
         node.on('input', function (msg) {
-            var client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
-
-
-            client.body = msg.payload;
+            var errorFlag = false;
+            var client;
+            if (this.service && this.service.host) {
+                client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
+            } else {
+                node.error('Host in configuration node is not specified.', msg);
+                errorFlag = true;
+            }
+            if (!errorFlag) {
+                client.body = msg.payload;
+            }
 
             var result;
-            var errorFlag = false;
-            if (node.method === 'get_metadata') {
-                var parameters = [], nodeParam, nodeParamType;
-
-                result = client.get_metadata(parameters);
+            if (!errorFlag && node.method === 'get_metadata') {
+                var get_metadata_parameters = [];
+                var get_metadata_nodeParam;
+                var get_metadata_nodeParamType;
+                result = client.get_metadata(get_metadata_parameters);
             }
-            
-            if (node.method === 'predict') {
+            if (!errorFlag && node.method === 'predict') {
                 var parameters = [], nodeParam, nodeParamType;
 
                 nodeParam = node.predict_audio;
                 nodeParamType = node.predict_audioType;
-                parameters.audio = msg.payload; 
                 
+                if (typeof msg.payload === 'object') {
+                    parameters.audio = msg.payload;
+                } else {
+                    node.error('Unsupported type: \'' + (typeof msg.payload) + '\', ' + 'msg.payload must be JSON object or buffer.', msg);
+                    errorFlag = true;
+                }
+
                 result = client.predict(parameters);
             }
-            
+            if (!errorFlag && result === undefined) {
+                node.error('Method is not specified.', msg);
+                errorFlag = true;
+            }
             if (!errorFlag) {
                 node.status({ fill: "blue", shape: "dot", text: "ModelAssetExchangeServer.status.requesting" });
                 result.then(function (response) {
                     if (node.method === 'get_metadata') {
                         msg.payload = response.body;
                     }
-
-                    if (node.method === 'predict' && response.body !== null && response.body !== undefined) {
-                        msg.payload = response.body.predictions[0].label || "Detection Error";
+                    if (node.method === 'predict') {
+                        if (response.body !== null && response.body !== undefined) {
+                            msg.payload = response.body.predictions[0].label || "Detection Error";
+                        } else {
+                            msg.payload = null;
+                        }
                     }
+                    
                     node.send(msg);
                     node.status({});
                 }).catch(function (error) {

--- a/facial-age-estimator/lib.js
+++ b/facial-age-estimator/lib.js
@@ -77,7 +77,29 @@ var ModelAssetExchangeServer = (function(){
         });
     };
 
+/**
+ * Return the metadata associated with the model
+ * @method
+ * @name ModelAssetExchangeServer#get_metadata
+ * @param {object} parameters - method options and parameters
+ */
+ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
+    if(parameters === undefined) {
+        parameters = {};
+    }
+    var deferred = Q.defer();
+    var domain = this.domain,  path = '/model/metadata';
+    var body = {}, queryParameters = {}, headers = {}, form = {};
 
+        headers['Accept'] = ['application/json'];
+        headers['Content-Type'] = ['application/json'];
+
+    queryParameters = mergeQueryParams(parameters, queryParameters);
+
+    this.request('GET', domain + path, parameters, body, headers, queryParameters, form, deferred);
+
+    return deferred.promise;
+ };
 /**
  * Make a prediction given input data
  * @method

--- a/facial-age-estimator/locales/de-DE/node.json
+++ b/facial-age-estimator/locales/de-DE/node.json
@@ -12,6 +12,7 @@
             "requesting": "Anfrage..."
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "Optionen"

--- a/facial-age-estimator/locales/en-US/node.json
+++ b/facial-age-estimator/locales/en-US/node.json
@@ -12,6 +12,7 @@
             "requesting": "requesting"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "Options"

--- a/facial-age-estimator/locales/ja/node.json
+++ b/facial-age-estimator/locales/ja/node.json
@@ -12,6 +12,7 @@
             "requesting": "要求中"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "任意項目"

--- a/facial-age-estimator/locales/zh-CN/node.json
+++ b/facial-age-estimator/locales/zh-CN/node.json
@@ -12,6 +12,7 @@
             "requesting": "请求中"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "可选项"

--- a/facial-age-estimator/node.html
+++ b/facial-age-estimator/node.html
@@ -22,7 +22,7 @@
                 var firstMethod = methods.first();
                 $('#node-input-method').val(firstMethod.val());
             }
-            $('#node-input-row-method').hide();
+            
 
             var showParameters = function () {
 
@@ -72,6 +72,7 @@
     <div class="form-row" id="node-input-row-method">
         <label for="node-input-method"><i class="icon-tasks"></i> <span data-i18n="ModelAssetExchangeServer.label.method"></span></label>
         <select id="node-input-method">
+            <option value="get_metadata" data-i18n="ModelAssetExchangeServer.parameters.get_metadata"></option>
             <option value="predict" data-i18n="ModelAssetExchangeServer.parameters.predict"></option>
         </select>
         &nbsp;

--- a/facial-age-estimator/node.html
+++ b/facial-age-estimator/node.html
@@ -96,17 +96,39 @@
 
 <script type="text/x-red" data-help-name="facial-age-estimator">
 
-    <p>This repository contains code to instantiate and deploy a facial age estimation model. The model detects faces in an image, extracts facial features for each face detected and finally predicts the age of each face. The model uses a coarse-to-fine strategy to perform multi-class classification and regression for age estimation. The input to the model is an image and the output is a list of estimated ages and bounding box coordinates of each face detected in the image. The format of the bounding box coordinates is [xmin, ymin, width, height]. The model is based on the SSR-Net model. The model files are hosted on IBM Cloud Object Storage. The code in this repository deploys the model as a web service in a Docker container. This repository was developed as part of the IBM Code Model Asset Exchange.</p>
-    <h3>Inputs</h3>
+    <p>
+    This repository contains code to instantiate and deploy a facial age estimation model. The model detects faces in an
+    image, extracts facial features for each face detected and finally predicts the age of each face. The model uses a
+    coarse-to-fine strategy to perform multi-class classification and regression for age estimation. The input to the
+    model is an image and the output is a list of estimated ages and bounding box coordinates of each face detected in
+    the image. The format of the bounding box coordinates is [xmin, ymin, width, height]. The model is based on the
+    SSR-Net model. The model files are hosted on IBM Cloud Object Storage. The code in this repository deploys the model
+    as a web service in a Docker container. This repository was developed as part of the IBM Code Model Asset Exchange.
+    </p>
+    <hr>
+    <h1>predict</h1>
+    <h3>Inputs:</h3>
     <dl class="message-properties">
-       <dt>payload<span class="property-type">Buffer</span></dt>
-       <dd>Buffer data of PNG or JPEG image.</dd>
+      <dt>payload <span class="property-type">Buffer</span></dt>
+      <dd>Buffer data of PNG or JPEG image.</dd>
     </dl>
-    <h3>Outputs</h3>
+    <h3>Outputs:</h3>
     <dl class="message-properties">
-        <dt>payload<span class="property-type">object</span></dt>
-        <dd>Predicted data.</dd>
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Predicted data.</dd>
     </dl>
+    <br>
+    <h1>metadata</h1>
+    <h3>Inputs:</h3>
+    <dl class="message-properties">
+      <dt>none <span class="property-type">none</span></dt>
+    </dl>
+    <h3>Outputs:</h3>
+    <dl class="message-properties">
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Returns the metadata associated with the model.</dd>
+    </dl>
+
 </script>
 <script type="text/javascript">
     RED.nodes.registerType('facial-age-estimator-service', {

--- a/facial-recognizer/lib.js
+++ b/facial-recognizer/lib.js
@@ -77,7 +77,29 @@ var ModelAssetExchangeServer = (function(){
         });
     };
 
+/**
+ * Return the metadata associated with the model
+ * @method
+ * @name ModelAssetExchangeServer#get_metadata
+ * @param {object} parameters - method options and parameters
+ */
+ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
+    if(parameters === undefined) {
+        parameters = {};
+    }
+    var deferred = Q.defer();
+    var domain = this.domain,  path = '/model/metadata';
+    var body = {}, queryParameters = {}, headers = {}, form = {};
 
+        headers['Accept'] = ['application/json'];
+        headers['Content-Type'] = ['application/json'];
+
+    queryParameters = mergeQueryParams(parameters, queryParameters);
+
+    this.request('GET', domain + path, parameters, body, headers, queryParameters, form, deferred);
+
+    return deferred.promise;
+ };
 /**
  * Make a prediction given input data
  * @method

--- a/facial-recognizer/locales/de-DE/node.json
+++ b/facial-recognizer/locales/de-DE/node.json
@@ -12,6 +12,7 @@
             "requesting": "Anfrage..."
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "Optionen"

--- a/facial-recognizer/locales/en-US/node.json
+++ b/facial-recognizer/locales/en-US/node.json
@@ -12,6 +12,7 @@
             "requesting": "requesting"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "Options"

--- a/facial-recognizer/locales/ja/node.json
+++ b/facial-recognizer/locales/ja/node.json
@@ -12,6 +12,7 @@
             "requesting": "要求中"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "任意項目"

--- a/facial-recognizer/locales/zh-CN/node.json
+++ b/facial-recognizer/locales/zh-CN/node.json
@@ -12,6 +12,7 @@
             "requesting": "请求中"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "可选项"

--- a/facial-recognizer/node.html
+++ b/facial-recognizer/node.html
@@ -95,17 +95,36 @@
 
 <script type="text/x-red" data-help-name="facial-recognizer">
 
-    <p>The model detects faces in an input image and then generates an embedding vector for each face. The generated embeddings can be used for downstream tasks such as classification, clustering, verification etc. The model accepts an image as input and returns the bounding box coordinates, probability and embedding vector for each face detected in the image. The model is based on the the FaceNet model.</p>
-    <h3>Inputs</h3>
+    <p>
+    The model detects faces in an input image and then generates an embedding vector for each face. The generated
+    embeddings can be used for downstream tasks such as classification, clustering, verification etc. The model accepts
+    an image as input and returns the bounding box coordinates, probability and embedding vector for each face detected
+    in the image. The model is based on the the FaceNet model.
+    </p>
+    <hr>
+    <h1>predict</h1>
+    <h3>Inputs:</h3>
     <dl class="message-properties">
-       <dt>payload<span class="property-type">Buffer</span></dt>
-       <dd>Buffer data of PNG or JPEG image.</dd>
+      <dt>payload <span class="property-type">Buffer</span></dt>
+      <dd>Buffer data of PNG or JPEG image.</dd>
     </dl>
-    <h3>Outputs</h3>
+    <h3>Outputs:</h3>
     <dl class="message-properties">
-        <dt>payload<span class="property-type">object</span></dt>
-        <dd>Predicted data.</dd>
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Predicted data.</dd>
     </dl>
+    <br>
+    <h1>metadata</h1>
+    <h3>Inputs:</h3>
+    <dl class="message-properties">
+      <dt>none <span class="property-type">none</span></dt>
+    </dl>
+    <h3>Outputs:</h3>
+    <dl class="message-properties">
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Returns the metadata associated with the model.</dd>
+    </dl>
+    
 </script>
 <script type="text/javascript">
     RED.nodes.registerType('facial-recognizer-service', {

--- a/facial-recognizer/node.html
+++ b/facial-recognizer/node.html
@@ -22,7 +22,6 @@
                 var firstMethod = methods.first();
                 $('#node-input-method').val(firstMethod.val());
             }
-            $('#node-input-row-method').hide();
 
             var showParameters = function () {
 
@@ -72,6 +71,7 @@
     <div class="form-row" id="node-input-row-method">
         <label for="node-input-method"><i class="icon-tasks"></i> <span data-i18n="ModelAssetExchangeServer.label.method"></span></label>
         <select id="node-input-method">
+                <option value="get_metadata" data-i18n="ModelAssetExchangeServer.parameters.get_metadata"></option>
             <option value="predict" data-i18n="ModelAssetExchangeServer.parameters.predict"></option>
         </select>
         &nbsp;

--- a/facial-recognizer/node.js
+++ b/facial-recognizer/node.js
@@ -24,6 +24,12 @@ module.exports = function (RED) {
             }
 
             var result;
+            if (!errorFlag && node.method === 'get_metadata') {
+                var get_metadata_parameters = [];
+                var get_metadata_nodeParam;
+                var get_metadata_nodeParamType;
+                result = client.get_metadata(get_metadata_parameters);
+            }
             if (!errorFlag && node.method === 'predict') {
                 var predict_parameters = [];
                 var predict_nodeParam;
@@ -55,10 +61,15 @@ module.exports = function (RED) {
                         }
                     }
                     if (data.body) {
-                        if (data.body.predictions && data.body.predictions.length > 0) {
-                            msg.payload = data.body.predictions[0].detection_box;
-                        } else {
-                            msg.payload = null;
+                        if (node.method === 'get_metadata') {
+                            msg.payload = data.body;
+                        }
+                        if (node.method === 'predict') {
+                            if (data.body.predictions && data.body.predictions.length > 0) {
+                                msg.payload = data.body.predictions[0].detection_box;
+                            } else {
+                                msg.payload = null;
+                            }
                         }
                         msg.details = data.body;
                     }

--- a/human-pose-estimator/lib.js
+++ b/human-pose-estimator/lib.js
@@ -79,6 +79,29 @@ var ModelAssetExchangeServer = (function(){
 
 
 /**
+ * Return the metadata associated with the model
+ * @method
+ * @name ModelAssetExchangeServer#get_metadata
+ * @param {object} parameters - method options and parameters
+ */
+ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
+    if(parameters === undefined) {
+        parameters = {};
+    }
+    var deferred = Q.defer();
+    var domain = this.domain,  path = '/model/metadata';
+    var body = {}, queryParameters = {}, headers = {}, form = {};
+
+        headers['Accept'] = ['application/json'];
+        headers['Content-Type'] = ['application/json'];
+
+    queryParameters = mergeQueryParams(parameters, queryParameters);
+
+    this.request('GET', domain + path, parameters, body, headers, queryParameters, form, deferred);
+
+    return deferred.promise;
+ };
+/**
  * Make a prediction given input data
  * @method
  * @name ModelAssetExchangeServer#predict

--- a/human-pose-estimator/locales/de-DE/node.json
+++ b/human-pose-estimator/locales/de-DE/node.json
@@ -12,6 +12,7 @@
             "requesting": "Anfrage..."
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "Optionen"

--- a/human-pose-estimator/locales/en-US/node.json
+++ b/human-pose-estimator/locales/en-US/node.json
@@ -12,6 +12,7 @@
             "requesting": "requesting"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "Options"

--- a/human-pose-estimator/locales/ja/node.json
+++ b/human-pose-estimator/locales/ja/node.json
@@ -12,6 +12,7 @@
             "requesting": "要求中"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "任意項目"

--- a/human-pose-estimator/locales/zh-CN/node.json
+++ b/human-pose-estimator/locales/zh-CN/node.json
@@ -12,6 +12,7 @@
             "requesting": "请求中"
         },
         "parameters": {
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "optionalParameters": "可选项"

--- a/human-pose-estimator/node.html
+++ b/human-pose-estimator/node.html
@@ -57,7 +57,6 @@
             $("#optional-parameters").change(function () {
                 showParameters();
             });
-            $('#node-input-row-method').hide();
 
         }
     });
@@ -72,6 +71,7 @@
     <div class="form-row" id="node-input-row-method">
         <label for="node-input-method"><i class="icon-tasks"></i> <span data-i18n="ModelAssetExchangeServer.label.method"></span></label>
         <select id="node-input-method">
+                <option value="get_metadata" data-i18n="ModelAssetExchangeServer.parameters.get_metadata"></option>
             <option value="predict" data-i18n="ModelAssetExchangeServer.parameters.predict"></option>
         </select>
         &nbsp;

--- a/human-pose-estimator/node.html
+++ b/human-pose-estimator/node.html
@@ -95,17 +95,36 @@
 
 <script type="text/x-red" data-help-name="human-pose-estimator">
 
-    <p>This model detects humans and their poses in a given image. The model first detects the humans in the input image and then identifies the body parts, including nose, neck, eyes, shoulders, elbows, wrists, hips, knees, and ankles. Next, each pair of associated body parts is connected by a pose line. The pose lines are assembled into full body poses for each of the humans detected in the image. The model is based on the TF implementation of OpenPose model.</p>
-    <h3>Inputs</h3>
+    <p>
+    This model detects humans and their poses in a given image. The model first detects the humans in the input image
+    and then identifies the body parts, including nose, neck, eyes, shoulders, elbows, wrists, hips, knees, and ankles.
+    Next, each pair of associated body parts is connected by a pose line. The pose lines are assembled into full body
+    poses for each of the humans detected in the image. The model is based on the TF implementation of OpenPose model.
+    </p>
+    <hr>
+    <h1>predict</h1>
+    <h3>Inputs:</h3>
     <dl class="message-properties">
-       <dt>payload<span class="property-type">Buffer</span></dt>
-       <dd>Buffer data of jpeg image.</dd>
+      <dt>payload <span class="property-type">Buffer</span></dt>
+      <dd>Buffer data of PNG or JPEG image.</dd>
     </dl>
-    <h3>Outputs</h3>
+    <h3>Outputs:</h3>
     <dl class="message-properties">
-        <dt>payload<span class="property-type">object</span></dt>
-        <dd>Predicted data.</dd>
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Predicted data.</dd>
     </dl>
+    <br>
+    <h1>metadata</h1>
+    <h3>Inputs:</h3>
+    <dl class="message-properties">
+      <dt>none <span class="property-type">none</span></dt>
+    </dl>
+    <h3>Outputs:</h3>
+    <dl class="message-properties">
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Returns the metadata associated with the model.</dd>
+    </dl>
+    
 </script>
 <script type="text/javascript">
     RED.nodes.registerType('human-pose-estimator-service', {

--- a/human-pose-estimator/node.js
+++ b/human-pose-estimator/node.js
@@ -24,6 +24,12 @@ module.exports = function (RED) {
             }
 
             var result;
+            if (!errorFlag && node.method === 'get_metadata') {
+                var get_metadata_parameters = [];
+                var get_metadata_nodeParam;
+                var get_metadata_nodeParamType;
+                result = client.get_metadata(get_metadata_parameters);
+            }
             if (!errorFlag && node.method === 'predict') {
                 var predict_parameters = [];
                 var predict_nodeParam;
@@ -55,10 +61,15 @@ module.exports = function (RED) {
                         }
                     }
                     if (data.body) {
-                        if (data.body.predictions && data.body.predictions.length > 0) {
-                            msg.payload = data.body.predictions[0].body_parts;
-                        } else {
-                            msg.payload = null;
+                        if (node.method === 'get_metadata') {
+                            msg.payload = data.body;
+                        }
+                        if (node.method === 'predict') {
+                            if (data.body.predictions && data.body.predictions.length > 0) {
+                                msg.payload = data.body.predictions[0].body_parts;
+                            } else {
+                                msg.payload = null;
+                            }
                         }
                         msg.details = data.body;
                     }

--- a/image-caption-generator/node.html
+++ b/image-caption-generator/node.html
@@ -115,24 +115,24 @@
     <h1>predict</h1>
     <h3>Inputs:</h3>
     <dl class="message-properties">
-        <dt>payload <span class="property-type">Buffer</span></dt>
-        <dd>Buffer data of PNG or JPEG image.</dd>
+      <dt>payload <span class="property-type">Buffer</span></dt>
+      <dd>Buffer data of PNG or JPEG image.</dd>
     </dl>
     <h3>Outputs:</h3>
     <dl class="message-properties">
-        <dt>payload <span class="property-type">object</span></dt>
-        <dd>Predicted data.</dd>
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Predicted data.</dd>
     </dl>
     <br>
-    <h1>get_metadata</h1>
+    <h1>metadata</h1>
     <h3>Inputs:</h3>
     <dl class="message-properties">
-        <dt>none <span class="property-type">none</span></dt>
+      <dt>none <span class="property-type">none</span></dt>
     </dl>
     <h3>Outputs:</h3>
     <dl class="message-properties">
-        <dt>payload <span class="property-type">object</span></dt>
-        <dd>Returns the metadata associated with the model.</dd>
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Returns the metadata associated with the model.</dd>
     </dl>
 </script>
 <script type="text/javascript">

--- a/object-detector/lib.js
+++ b/object-detector/lib.js
@@ -31,6 +31,53 @@ var ModelAssetExchangeServer = (function(){
         return queryParameters;
     }
 
+
+    /**
+     * Return the list of labels that can be predicted by the model
+     * @method
+     * @name ModelAssetExchangeServer#get_labels
+     * @param {object} parameters - method options and parameters
+     */
+    ModelAssetExchangeServer.prototype.get_labels = function(parameters){
+        if(parameters === undefined) {
+            parameters = {};
+        }
+        var deferred = Q.defer();
+        var domain = this.domain,  path = '/model/labels';
+        var body = {}, queryParameters = {}, headers = {}, form = {};
+
+            headers['Accept'] = ['application/json'];
+            headers['Content-Type'] = ['application/json'];
+
+        queryParameters = mergeQueryParams(parameters, queryParameters);
+
+        this.request('GET', domain + path, parameters, body, headers, queryParameters, form, deferred);
+
+        return deferred.promise;
+    };
+    /**
+     * Return the metadata associated with the model
+     * @method
+     * @name ModelAssetExchangeServer#get_metadata
+     * @param {object} parameters - method options and parameters
+     */
+    ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
+        if(parameters === undefined) {
+            parameters = {};
+        }
+        var deferred = Q.defer();
+        var domain = this.domain,  path = '/model/metadata';
+        var body = {}, queryParameters = {}, headers = {}, form = {};
+
+            headers['Accept'] = ['application/json'];
+            headers['Content-Type'] = ['application/json'];
+
+        queryParameters = mergeQueryParams(parameters, queryParameters);
+
+        this.request('GET', domain + path, parameters, body, headers, queryParameters, form, deferred);
+
+        return deferred.promise;
+    };
     /**
      * HTTP Request
      * @method

--- a/object-detector/locales/de-DE/node.json
+++ b/object-detector/locales/de-DE/node.json
@@ -12,6 +12,8 @@
             "requesting": "Anfrage..."
         },
         "parameters": {
+            "get_labels": "labels",
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "threshold": "threshold",

--- a/object-detector/locales/en-US/node.json
+++ b/object-detector/locales/en-US/node.json
@@ -12,6 +12,8 @@
             "requesting": "requesting"
         },
         "parameters": {
+            "get_labels": "labels",
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "threshold": "threshold",

--- a/object-detector/locales/ja/node.json
+++ b/object-detector/locales/ja/node.json
@@ -12,6 +12,8 @@
             "requesting": "要求中"
         },
         "parameters": {
+            "get_labels": "labels",
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "threshold": "threshold",

--- a/object-detector/locales/zh-CN/node.json
+++ b/object-detector/locales/zh-CN/node.json
@@ -12,6 +12,8 @@
             "requesting": "请求中"
         },
         "parameters": {
+            "get_labels": "labels",
+            "get_metadata": "metadata",
             "predict": "predict",
             "body": "body",
             "threshold": "threshold",

--- a/object-detector/node.html
+++ b/object-detector/node.html
@@ -118,16 +118,46 @@
 
 <script type="text/x-red" data-help-name="object-detector">
 
-    <p>This model recognizes the objects present in an image from the 80 different high-level classes of objects in the COCO Dataset. The model consists of a deep convolutional net base model for image feature extraction, together with additional convolutional layers specialized for the task of object detection, that was trained on the COCO data set. The input to the model is an image, and the output is a list of estimated class probabilities for the objects detected in the image. The model is based on the SSD Mobilenet V1 object detection model for TensorFlow.</p>
-    <h3>Inputs</h3>
+    <p>
+    This model recognizes the objects present in an image from the 80 different high-level classes of objects in the
+    COCO Dataset. The model consists of a deep convolutional net base model for image feature extraction, together with
+    additional convolutional layers specialized for the task of object detection, that was trained on the COCO data
+    set. The input to the model is an image, and the output is a list of estimated class probabilities for the objects
+    detected in the image. The model is based on the SSD Mobilenet V1 object detection model for TensorFlow.
+    </p>
+    <hr>
+    <h1>predict</h1>
+    <h3>Inputs:</h3>
     <dl class="message-properties">
-       <dt>payload<span class="property-type">Buffer</span></dt>
-       <dd>Buffer data of PNG or JPEG image.</dd>
+      <dt>payload <span class="property-type">Buffer</span></dt>
+      <dd>Buffer data of PNG or JPEG image.</dd>
     </dl>
-    <h3>Outputs</h3>
+    <h3>Outputs:</h3>
     <dl class="message-properties">
-        <dt>payload<span class="property-type">object</span></dt>
-        <dd>Predicted data.</dd>
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Predicted data.</dd>
+    </dl>
+    <br>
+    <h1>labels</h1>
+    <h3>Inputs:</h3>
+    <dl class="message-properties">
+      <dt>none <span class="property-type">none</span></dt>
+    </dl>
+    <h3>Outputs:</h3>
+    <dl class="message-properties">
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Returns the list of labels that can be predicted by the model.</dd>
+    </dl>
+    <br>
+    <h1>metadata</h1>
+    <h3>Inputs:</h3>
+    <dl class="message-properties">
+      <dt>none <span class="property-type">none</span></dt>
+    </dl>
+    <h3>Outputs:</h3>
+    <dl class="message-properties">
+      <dt>payload <span class="property-type">object</span></dt>
+      <dd>Returns the metadata associated with the model.</dd>
     </dl>
 </script>
 <script type="text/javascript">

--- a/object-detector/node.html
+++ b/object-detector/node.html
@@ -24,7 +24,6 @@
                 var firstMethod = methods.first();
                 $('#node-input-method').val(firstMethod.val());
             }
-            $('#node-input-row-method').hide();
 
             var showParameters = function () {
 
@@ -87,6 +86,8 @@
     <div class="form-row" id="node-input-row-method">
         <label for="node-input-method"><i class="icon-tasks"></i> <span data-i18n="ModelAssetExchangeServer.label.method"></span></label>
         <select id="node-input-method">
+            <option value="get_labels" data-i18n="ModelAssetExchangeServer.parameters.get_labels"></option>    
+            <option value="get_metadata" data-i18n="ModelAssetExchangeServer.parameters.get_metadata"></option>
             <option value="predict" data-i18n="ModelAssetExchangeServer.parameters.predict"></option>
         </select>
         &nbsp;

--- a/object-detector/node.js
+++ b/object-detector/node.js
@@ -26,6 +26,18 @@ module.exports = function (RED) {
             }
 
             var result;
+            if (!errorFlag && node.method === 'get_labels') {
+                var get_labels_parameters = [];
+                var get_labels_nodeParam;
+                var get_labels_nodeParamType;
+                result = client.get_labels(get_labels_parameters);
+            }
+            if (!errorFlag && node.method === 'get_metadata') {
+                var get_metadata_parameters = [];
+                var get_metadata_nodeParam;
+                var get_metadata_nodeParamType;
+                result = client.get_metadata(get_metadata_parameters);
+            }
             if (!errorFlag && node.method === 'predict') {
                 var predict_parameters = [];
                 var predict_nodeParam;
@@ -65,10 +77,18 @@ module.exports = function (RED) {
                         }
                     }
                     if (data.body) {
-                        if (data.body.predictions && data.body.predictions.length > 0) {
-                            msg.payload = data.body.predictions[0].label;
-                        } else {
-                            msg.payload = null;
+                        if (node.method === 'get_metadata') {
+                            msg.payload = data.body;
+                        }
+                        if (node.method === 'get_labels') {
+                            msg.payload = data.body;
+                        }
+                        if (node.method === 'predict') {
+                            if (data.body.predictions && data.body.predictions.length > 0) {
+                                msg.payload = data.body.predictions[0].label;
+                            } else {
+                                msg.payload = null;
+                            }
                         }
                         msg.details = data.body;
                     }


### PR DESCRIPTION
This change brings the `metadata` method to all nodes, and the `labels` method to object-detector, as per each models OpenAPI spec.

The `get_` prefix has been removed from these `GET` request methods, to more closely match the method/route name of the underlying service and the spec.

The default method for each node is `predict`.

Documentation has been updated for each node to reflect the additional methods and for a standardized format across the nodes.