### PR TITLE
add repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
       "audio-classifier": "audio-classifier/node.js"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CODAIT/node-red-contrib-model-asset-exchange.git"
+  },
   "keywords": [
     "node-red",
     "model asset exchange",


### PR DESCRIPTION
This addition to package.json will allow the static content (images) to load on the README hosted on npm.