### PR TITLE
Add file-type module into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "dependencies": {
     "q": "1.5.1",
-    "request": "2.83.0"
+    "request": "2.83.0",
+    "file-type": "^10.7.1"
   },
   "devDependencies": {
     "mocha": "^6.0.0",


### PR DESCRIPTION
To add nodes generated by Node generator v0.0.3, we need to add `file-type` module to dependencies.