### PR TITLE
ignore trailing slashes in host URLs

### DIFF
--- a/audio-classifier/node.js
+++ b/audio-classifier/node.js
@@ -15,7 +15,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/audio-classifier/node.js
+++ b/audio-classifier/node.js
@@ -6,7 +6,6 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, config);
         this.service = RED.nodes.getNode(config.service);
         this.method = config.method;
-
         this.predict_audio = config.predict_audio;
         this.predict_audioType = config.predict_audioType || 'str';
 
@@ -16,6 +15,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/facial-age-estimator/node.js
+++ b/facial-age-estimator/node.js
@@ -14,7 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/facial-age-estimator/node.js
+++ b/facial-age-estimator/node.js
@@ -14,6 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/facial-recognizer/node.js
+++ b/facial-recognizer/node.js
@@ -14,7 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/facial-recognizer/node.js
+++ b/facial-recognizer/node.js
@@ -14,6 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/human-pose-estimator/node.js
+++ b/human-pose-estimator/node.js
@@ -14,7 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/human-pose-estimator/node.js
+++ b/human-pose-estimator/node.js
@@ -14,6 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/image-caption-generator/node.js
+++ b/image-caption-generator/node.js
@@ -14,7 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/image-caption-generator/node.js
+++ b/image-caption-generator/node.js
@@ -14,6 +14,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/image-segmenter/node.js
+++ b/image-segmenter/node.js
@@ -13,10 +13,10 @@ module.exports = function (RED) {
         var node = this;
 
         node.on('input', function (msg) {
-            var client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             var errorFlag = false;
-
+            var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/image-segmenter/node.js
+++ b/image-segmenter/node.js
@@ -16,7 +16,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/inception-resnet-v2/node.js
+++ b/inception-resnet-v2/node.js
@@ -16,6 +16,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/inception-resnet-v2/node.js
+++ b/inception-resnet-v2/node.js
@@ -16,7 +16,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/object-detector/node.js
+++ b/object-detector/node.js
@@ -16,6 +16,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/object-detector/node.js
+++ b/object-detector/node.js
@@ -16,7 +16,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/scene-classifier/node.js
+++ b/scene-classifier/node.js
@@ -16,6 +16,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
+                this.service.host = this.service.host.replace(/\/$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);

--- a/scene-classifier/node.js
+++ b/scene-classifier/node.js
@@ -16,7 +16,7 @@ module.exports = function (RED) {
             var errorFlag = false;
             var client;
             if (this.service && this.service.host) {
-                this.service.host = this.service.host.replace(/\/$/, '');
+                this.service.host = this.service.host.replace(/\/+$/, '');
                 client = new lib.ModelAssetExchangeServer({ domain: this.service.host });
             } else {
                 node.error('Host in configuration node is not specified.', msg);


### PR DESCRIPTION
Fixes #22 

This would handle URLs with a slash on the end, like `https://max-audio-classifier.max.us-south.containers.appdomain.cloud/` being used for the service host.

The change applies to all 9 models in the package.