### PR TITLE
i42: fix regression tests

### DIFF
--- a/facial-age-estimator/test/node_spec.js
+++ b/facial-age-estimator/test/node_spec.js
@@ -65,7 +65,7 @@ describe('facial-age-estimator node', function () {
             var n1 = helper.getNode('n1');
             n3.on('input', function (msg) {
                 try {
-                    msg.should.have.property('payload', 48);
+                    msg.should.have.property('payload', 39);
                     done();
                 } catch (e) {
                     done(e);

--- a/facial-recognizer/test/node_spec.js
+++ b/facial-recognizer/test/node_spec.js
@@ -42,7 +42,7 @@ describe('facial-recognizer node', function () {
             var n1 = helper.getNode('n1');
             n3.on('input', function (msg) {
                 try {
-                    msg.payload.should.have.property('id', 'facenet-tensorflow');
+                    msg.payload.should.have.property('id', 'max-facial-recognizer');
                     done();
                 } catch (e) {
                     done(e);

--- a/image-caption-generator/test/node_spec.js
+++ b/image-caption-generator/test/node_spec.js
@@ -42,7 +42,7 @@ describe('image-caption-generator node', function () {
             var n1 = helper.getNode('n1');
             n3.on('input', function (msg) {
                 try {
-                    msg.payload.should.have.property('id', 'im2txt-tensorflow');
+                    msg.payload.should.have.property('id', 'max-image-caption-generator');
                     done();
                 } catch (e) {
                     done(e);

--- a/image-segmenter/test/node_spec.js
+++ b/image-segmenter/test/node_spec.js
@@ -42,7 +42,7 @@ describe('image-segmenter node', function () {
             var n1 = helper.getNode('n1');
             n3.on('input', function (msg) {
                 try {
-                    msg.payload.should.have.property('id', 'deeplab-tf');
+                    msg.payload.should.have.property('id', 'max-image-segmenter');
                     done();
                 } catch (e) {
                     done(e);


### PR DESCRIPTION
Fixes the following issues:
 - accept new values for standardized metadata property `id`
 - accommodate facial age estimator model changes, which return a different result for the test image

Closes #42 
