### PR TITLE
updated payload and unit tests

### DIFF
--- a/facial-emotion-classifier/node.js
+++ b/facial-emotion-classifier/node.js
@@ -76,16 +76,7 @@ module.exports = function (RED) {
                         if (node.method === 'predict') {
                             if (data.body.predictions && data.body.predictions.length > 0) {
                                 const predictions = data.body.predictions.map(person => person.emotion_predictions[0].label);
-                                msg.payload = {
-                                    entitiesDetected: 1,
-                                    prediction: [predictions[0]]
-                                }
-                                if (data.body.predictions.length > 1) {
-                                    msg.payload = {
-                                        entitiesDetected: data.body.predictions.length,
-                                        prediction: predictions
-                                    }
-                                } 
+                                msg.payload = predictions[0]
                             } else {
                                 msg.payload = null;
                             }

--- a/facial-emotion-classifier/test/node_spec.js
+++ b/facial-emotion-classifier/test/node_spec.js
@@ -100,9 +100,7 @@ describe('facial-emotion-classifier node', function () {
             var n1 = helper.getNode('n1');
             n3.on('input', function (msg) {
                 try {
-                    msg.payload.should.have.keys(['entitiesDetected','prediction']);
-                    msg.payload.should.have.property('entitiesDetected', 1);
-                    msg.payload.prediction.should.matchAny('anger');
+                    msg.should.have.property('payload', 'anger');
                     done();
                 } catch (e) {
                     done(e);


### PR DESCRIPTION
updated the payload structure of the `facial-emotion-classifier` to be more in line with existing models and the desired format for Node-RED devs.

* `msg.payload` contains a string, containing the first (or only) prediction returned by the model.
* the complete response from the model is stored in `msg.details` 
