### PR TITLE
Convert visualizations to remove native dependencies 

### DIFF
--- a/examples/1-getting-started/object-detector.json
+++ b/examples/1-getting-started/object-detector.json
@@ -1,30 +1,30 @@
 [
     {
-        "id": "257b0fcf.c1302",
+        "id": "139602c0.ce5c8d",
         "type": "tab",
         "label": "Object detection example flow",
         "disabled": false,
-        "info": "This flow uses the https://developer.ibm.com/exchanges/models/all/max-object-detector/ deep learning model from the Model Asset Exchange to localize and identify multiple objects in a single image. Refer to the documentation for information about the returned message.\n\nInstall the following three modules to run this example flow:\n - [node-red-contrib-model-asset-exchange](https://www.npmjs.com/package/node-red-contrib-model-asset-exchange)\n - [node-red-contrib-browser-utils](https://www.npmjs.com/package/node-red-contrib-browser-utils)\n - [node-red-contrib-image-output](https://npmjs.org/package/node-red-contrib-image-output)\n \n> Note: The object-detector node has been pre-configured to use a hosted model evaluation instance. We recommend using your own local or cloud instance for purposes other than evaluation."
+        "info": "This flow uses the https://developer.ibm.com/exchanges/models/all/max-object-detector/ deep learning model from the Model Asset Exchange to localize and identify multiple objects in a single image. Refer to the documentation for information about the returned message.\n\nInstall the following three modules to run this example flow:\n - [node-red-contrib-model-asset-exchange](https://www.npmjs.com/package/node-red-contrib-model-asset-exchange)\n - [node-red-contrib-browser-utils](https://www.npmjs.com/package/node-red-contrib-browser-utils)\n - [node-red-contrib-image-output](https://npmjs.org/package/node-red-contrib-image-output)\n \n> Note: The object-detector node has been pre-configured to use a hosted model evaluation instance. We recommend using your own local or cloud instance for purposes other than evaluation.\n\nTo adjust the size of the image output in this flow, double-click the **Image output** node. Image width is set to 300px by default."
     },
     {
-        "id": "5680e5ee.1441cc",
+        "id": "a1293bd8.418448",
         "type": "debug",
-        "z": "257b0fcf.c1302",
+        "z": "139602c0.ce5c8d",
         "name": "",
         "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
         "complete": "true",
-        "x": 650,
-        "y": 120,
+        "x": 630,
+        "y": 140,
         "wires": []
     },
     {
-        "id": "d266c943.67ce48",
+        "id": "f596981b.ed9368",
         "type": "object-detector",
-        "z": "257b0fcf.c1302",
-        "service": "96195b68.679e18",
+        "z": "139602c0.ce5c8d",
+        "service": "594e4ad2.a17944",
         "method": "predict",
         "passthrough": false,
         "annotated_input": true,
@@ -33,45 +33,45 @@
         "predict_threshold": "0.7",
         "predict_thresholdType": "str",
         "name": "",
-        "x": 360,
-        "y": 120,
+        "x": 340,
+        "y": 140,
         "wires": [
             [
-                "5680e5ee.1441cc",
-                "9f36df26.ff3c9"
+                "a1293bd8.418448",
+                "ea4eeb9c.24b4f8"
             ]
         ]
     },
     {
-        "id": "b20eb66e.1fa248",
+        "id": "349ab2c1.15dc1e",
         "type": "fileinject",
-        "z": "257b0fcf.c1302",
+        "z": "139602c0.ce5c8d",
         "name": "",
-        "x": 140,
-        "y": 120,
+        "x": 120,
+        "y": 140,
         "wires": [
             [
-                "d266c943.67ce48"
+                "f596981b.ed9368"
             ]
         ]
     },
     {
-        "id": "520cd665.7725c8",
+        "id": "e468264a.e47008",
         "type": "camera",
-        "z": "257b0fcf.c1302",
+        "z": "139602c0.ce5c8d",
         "name": "",
-        "x": 130,
-        "y": 178,
+        "x": 110,
+        "y": 198,
         "wires": [
             [
-                "d266c943.67ce48"
+                "f596981b.ed9368"
             ]
         ]
     },
     {
-        "id": "f124cc22.5c93a",
+        "id": "37b11dcf.5010e2",
         "type": "comment",
-        "z": "257b0fcf.c1302",
+        "z": "139602c0.ce5c8d",
         "name": "Localize and identify multiple objects in a single image, then display the output",
         "info": "",
         "x": 320,
@@ -79,33 +79,43 @@
         "wires": []
     },
     {
-        "id": "fd5d2cbc.ed717",
+        "id": "13f86581.2e775a",
         "type": "image",
-        "z": "257b0fcf.c1302",
+        "z": "139602c0.ce5c8d",
         "name": "",
-        "width": "300",
-        "x": 670.5,
-        "y": 178,
+        "width": "600",
+        "x": 650.5,
+        "y": 198,
         "wires": []
     },
     {
-        "id": "9f36df26.ff3c9",
+        "id": "ea4eeb9c.24b4f8",
         "type": "function",
-        "z": "257b0fcf.c1302",
+        "z": "139602c0.ce5c8d",
         "name": "Extract Bounding Box Image Data",
         "func": "// if the incoming message contains the annotated image\n// send it to the image output node to display\n\nmsg.payload = msg.annotatedInput;\nif (msg.payload) {\n    return msg;\n}",
         "outputs": 1,
         "noerr": 0,
-        "x": 419.5,
-        "y": 178,
+        "x": 399.5,
+        "y": 198,
         "wires": [
             [
-                "fd5d2cbc.ed717"
+                "13f86581.2e775a"
             ]
         ]
     },
     {
-        "id": "96195b68.679e18",
+        "id": "b9fb347f.0c46d8",
+        "type": "comment",
+        "z": "139602c0.ce5c8d",
+        "name": "To adjust the size of the preview image, double-click the \"Image output\" node",
+        "info": "By default, the image width is set to 300px.",
+        "x": 310,
+        "y": 77,
+        "wires": []
+    },
+    {
+        "id": "594e4ad2.a17944",
         "type": "object-detector-service",
         "z": "",
         "host": "https://max-object-detector.max.us-south.containers.appdomain.cloud",

--- a/examples/2-beyond-the-basics/using-multiple-models.json
+++ b/examples/2-beyond-the-basics/using-multiple-models.json
@@ -1,15 +1,15 @@
 [
     {
-        "id": "fb9f2f1a.6de7f",
+        "id": "c85d6fc6.073c8",
         "type": "tab",
         "label": "Using Multiple Models",
         "disabled": false,
-        "info": "This flow uses the [object-detector](https://developer.ibm.com/exchanges/models/all/max-object-detector/) and [image-caption-generator](https://developer.ibm.com/exchanges/models/all/max-image-caption-generator/) deep learning models from the Model Asset Exchange to display bounding boxes on an input image, then displays a generated caption. Refer to the model documentation for information about the returned messages.\n\nInstall the following three modules to run this example flow:\n - [node-red-contrib-model-asset-exchange](https://www.npmjs.com/package/node-red-contrib-model-asset-exchange)\n - [node-red-contrib-browser-utils](https://www.npmjs.com/package/node-red-contrib-browser-utils)\n - [node-red-contrib-image-output](https://npmjs.org/package/node-red-contrib-image-output)\n \n> Note: The object-detector and image-caption-generator nodes have been pre-configured to use hosted model evaluation instances. We recommend using your own local or cloud instance for purposes other than evaluation."
+        "info": "This flow uses the [object-detector](https://developer.ibm.com/exchanges/models/all/max-object-detector/) and [image-caption-generator](https://developer.ibm.com/exchanges/models/all/max-image-caption-generator/) deep learning models from the Model Asset Exchange to display bounding boxes on an input image, then displays a generated caption. Refer to the model documentation for information about the returned messages.\n\nInstall the following three modules to run this example flow:\n - [node-red-contrib-model-asset-exchange](https://www.npmjs.com/package/node-red-contrib-model-asset-exchange)\n - [node-red-contrib-browser-utils](https://www.npmjs.com/package/node-red-contrib-browser-utils)\n - [node-red-contrib-image-output](https://npmjs.org/package/node-red-contrib-image-output)\n \n> Note: The object-detector and image-caption-generator nodes have been pre-configured to use hosted model evaluation instances. We recommend using your own local or cloud instance for purposes other than evaluation.\n\nTo adjust the size of the image output in this flow, double-click the **Image output** node. Image width is set to 300px by default."
     },
     {
-        "id": "6c39a79e.485748",
+        "id": "21299efc.027202",
         "type": "debug",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -18,14 +18,14 @@
         "complete": "payload",
         "targetType": "msg",
         "x": 1156,
-        "y": 120,
+        "y": 140,
         "wires": []
     },
     {
-        "id": "8bafdf80.fa7da",
+        "id": "749ca183.2c516",
         "type": "object-detector",
-        "z": "fb9f2f1a.6de7f",
-        "service": "96195b68.679e18",
+        "z": "c85d6fc6.073c8",
+        "service": "94e51296.226d3",
         "method": "predict",
         "passthrough": true,
         "annotated_input": true,
@@ -35,44 +35,44 @@
         "predict_thresholdType": "str",
         "name": "",
         "x": 360,
-        "y": 120,
+        "y": 140,
         "wires": [
             [
-                "dd67bf05.d8256",
-                "e3f9db88.50b798"
+                "3c7b9a30.a37726",
+                "982c6b4a.83d268"
             ]
         ]
     },
     {
-        "id": "2384d389.022c1c",
+        "id": "3f7754d6.450b7c",
         "type": "fileinject",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "name": "",
         "x": 140,
-        "y": 120,
+        "y": 140,
         "wires": [
             [
-                "8bafdf80.fa7da"
+                "749ca183.2c516"
             ]
         ]
     },
     {
-        "id": "7a3149a4.b9f218",
+        "id": "c6d9271a.9f1638",
         "type": "camera",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "name": "",
         "x": 130,
-        "y": 214,
+        "y": 234,
         "wires": [
             [
-                "8bafdf80.fa7da"
+                "749ca183.2c516"
             ]
         ]
     },
     {
-        "id": "5992ec00.f522e4",
+        "id": "58d91743.9557b8",
         "type": "comment",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "name": "Display bounding boxes on an input image using the object-detector node, then pass the input to the image-caption-generator to display a generated caption.",
         "info": "This flow uses the [object-detector](https://developer.ibm.com/exchanges/models/all/max-object-detector/) and [image-caption-generator](https://developer.ibm.com/exchanges/models/all/max-image-caption-generator/) deep learning models from the Model Asset Exchange to display bounding boxes on an input image, then displays a generated caption. Refer to the model documentation for information about the returned messages.\n\nInstall the following three modules to run this example flow:\n - [node-red-contrib-model-asset-exchange](https://www.npmjs.com/package/node-red-contrib-model-asset-exchange)\n - [node-red-contrib-browser-utils](https://www.npmjs.com/package/node-red-contrib-browser-utils)\n - [node-red-contrib-image-output](https://npmjs.org/package/node-red-contrib-image-output)\n \n> Note: The object-detector and image-caption-generator nodes have been pre-configured to use hosted model evaluation instances. We recommend using your own local or cloud instance for purposes other than evaluation.",
         "x": 560,
@@ -80,66 +80,76 @@
         "wires": []
     },
     {
-        "id": "62fba4c.11ec95c",
+        "id": "734d61db.26efc",
         "type": "image",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "name": "",
         "width": "300",
         "x": 774.5,
-        "y": 220,
+        "y": 240,
         "wires": []
     },
     {
-        "id": "dd67bf05.d8256",
+        "id": "3c7b9a30.a37726",
         "type": "function",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "name": "Extract Bounding Box Image Data",
         "func": "// if the incoming message contains the annotated image\n// send it to the image output node to display\n\nmsg.payload = msg.annotatedInput;\nif (msg.payload) {\n    return msg;\n}",
         "outputs": 1,
         "noerr": 0,
         "x": 479.5,
-        "y": 220,
+        "y": 240,
         "wires": [
             [
-                "62fba4c.11ec95c"
+                "734d61db.26efc"
             ]
         ]
     },
     {
-        "id": "49c3158c.658edc",
+        "id": "15a109d.d83fdf6",
         "type": "image-caption-generator",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "service": "82a87cae.a2fec",
         "method": "predict",
         "predict_body": "",
         "predict_bodyType": "str",
         "name": "",
         "x": 901.5,
-        "y": 120,
+        "y": 140,
         "wires": [
             [
-                "6c39a79e.485748"
+                "21299efc.027202"
             ]
         ]
     },
     {
-        "id": "e3f9db88.50b798",
+        "id": "982c6b4a.83d268",
         "type": "function",
-        "z": "fb9f2f1a.6de7f",
+        "z": "c85d6fc6.073c8",
         "name": "Extract Input Image Data",
         "func": "// if the incoming message contains the input image\n// send it to the image-caption-generator node\n// for further processing\n\nmsg.payload = msg.inputData;\nif (msg.payload) {\n    return msg;\n}",
         "outputs": 1,
         "noerr": 0,
         "x": 609,
-        "y": 120,
+        "y": 140,
         "wires": [
             [
-                "49c3158c.658edc"
+                "15a109d.d83fdf6"
             ]
         ]
     },
     {
-        "id": "96195b68.679e18",
+        "id": "fba399f2.69a038",
+        "type": "comment",
+        "z": "c85d6fc6.073c8",
+        "name": "To adjust the size of the preview image, double-click the \"Image output\" node",
+        "info": "By default, the image width is set to 300px.",
+        "x": 310,
+        "y": 77,
+        "wires": []
+    },
+    {
+        "id": "94e51296.226d3",
         "type": "object-detector-service",
         "z": "",
         "host": "https://max-object-detector.max.us-south.containers.appdomain.cloud",
@@ -148,7 +158,7 @@
     {
         "id": "82a87cae.a2fec",
         "type": "image-caption-generator-service",
-        "z": "",
+        "z": 0,
         "host": "https://max-image-caption-generator.max.us-south.containers.appdomain.cloud",
         "name": "cloud"
     }

--- a/facial-age-estimator/lib.js
+++ b/facial-age-estimator/lib.js
@@ -1,6 +1,8 @@
 /*jshint -W069 */
 
-const { createCanvas, Image } = require('canvas');
+const Jimp = require('jimp');
+const sizeOf = require('buffer-image-size');
+const { rect, rectFill, getScaledFont, getPadSize } = require('../utils');
 
 /**
  * This repository contains code to instantiate and deploy a facial age estimation model. The model detects faces in an image, extracts facial features for each face detected and finally predicts the age of each face. The model uses a coarse-to-fine strategy to perform multi-class classification and regression for age estimation. The input to the model is an image and the output is a list of estimated ages and bounding box coordinates of each face detected in the image. The format of the bounding box coordinates is [xmin, ymin, width, height]. The model is based on the SSR-Net model. The model files are hosted on IBM Cloud Object Storage. The code in this repository deploys the model as a web service in a Docker container. This repository was developed as part of the IBM Code Model Asset Exchange.
@@ -146,41 +148,26 @@ ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
 
 exports.ModelAssetExchangeServer = ModelAssetExchangeServer;
 
-exports.createAnnotatedInput = (imageData, modelData) => {
-    try {
-        let canvas;
-        const img = new Image();
-        img.onload = async () => {
-            canvas = createCanvas(img.width, img.height);
-            const ctx = canvas.getContext('2d')
-            const solidColor = '#1bc6c0';
-            const textColor = '#000';
-            ctx.drawImage(img, 0, 0);
-            const boxesArray = modelData.map((obj, i) => obj.face_box);
-            boxesArray.forEach((box, i) => {
-                ctx.font = '36px sans-serif';
-                ctx.textBaseline = 'top';
-                ctx.fillStyle = solidColor;
-                ctx.strokeStyle = solidColor;
-                ctx.lineWidth = "3";
-                // BOX GENERATION
-                const xMin = box[0];
-                const yMin = box[1];
-                ctx.strokeRect(...box);
-                // LABEL GENERATION
-                const label = modelData[i].age_estimation;
-                const tagWidth = ctx.measureText(label).width;
-                const tHeight = parseInt(ctx.font, 10) * 1.2;
-                ctx.fillRect(xMin, yMin, tagWidth + 3, tHeight);
-                ctx.fillStyle = textColor;
-                ctx.fillText(label, xMin + 2, yMin + 4);
-            })
-        }
-        img.onerror = err => { throw err }
-        img.src = imageData;
-        return canvas.toBuffer();
-    } catch (e) {
-        console.log(`error processing image - ${ e }`);
-        return null;
-    }
+exports.createAnnotatedInput = async (imageData, modelData) => {
+    const {width, height} = sizeOf(imageData);
+    let fontType = getScaledFont(width, 'black');
+    const font = await Jimp.loadFont(fontType);
+    const canvas = await Jimp.read(imageData);
+    const padSize = getPadSize(width);
+    modelData.map(obj => obj.detection_box).forEach((box, i) => {
+        // BOX GENERATION
+        const xMax = box[3] * width;
+        const xMin = box[1] * width;
+        const yMax = box[2] * height;
+        const yMin = box[0] * height;
+        rect(canvas, xMin, yMin, xMax, yMax, padSize, 'cyan');
+        // LABEL GENERATION
+        const text = String(modelData[i].age_estimation);
+        const textHeight = Jimp.measureTextHeight(font, text);
+        const xTagMax = Jimp.measureText(font, text) + (padSize*2) + xMin;
+        const yTagMin = yMin - textHeight > 0 ? yMin - textHeight : yMin;
+        rectFill(canvas, xMin, yTagMin, xTagMax, textHeight + yTagMin, padSize, 'cyan');
+        canvas.print(font, xMin + padSize, yTagMin, text);
+    });
+    return canvas.getBufferAsync(Jimp.AUTO);
 }

--- a/facial-age-estimator/node.js
+++ b/facial-age-estimator/node.js
@@ -53,7 +53,7 @@ module.exports = function (RED) {
                 node.error('Method is not specified.', msg);
                 errorFlag = true;
             }
-            var setData = function (msg, data) {
+            var setData = async function (msg, data) {
                 if (data) {
                     if (data.response) {
                         if (data.response.statusCode) {
@@ -74,7 +74,7 @@ module.exports = function (RED) {
                             if (data.body.predictions && data.body.predictions.length > 0) {
                                 msg.payload = data.body.predictions[0].age_estimation;
                                 if (node.annotated_input) {
-                                    msg.annotatedInput = lib.createAnnotatedInput(node.inputData, data.body.predictions);
+                                    msg.annotatedInput = await lib.createAnnotatedInput(node.inputData, data.body.predictions);
                                 }
                             } else {
                                 msg.payload = null;
@@ -91,8 +91,8 @@ module.exports = function (RED) {
             };
             if (!errorFlag) {
                 node.status({ fill: 'blue', shape: 'dot', text: 'ModelAssetExchangeServer.status.requesting' });
-                result.then(function (data) {
-                    node.send(setData(msg, data));
+                result.then(async function (data) {
+                    node.send(await setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
                     var message = null;

--- a/facial-emotion-classifier/lib.js
+++ b/facial-emotion-classifier/lib.js
@@ -1,6 +1,8 @@
 /*jshint -W069 */
 
-const { createCanvas, Image } = require('canvas');
+const Jimp = require('jimp');
+const sizeOf = require('buffer-image-size');
+const { rect, rectFill, getScaledFont, getPadSize } = require('../utils');
 
 /**
  * Detect faces in an image and predict the emotional state of each person
@@ -175,49 +177,26 @@ var MaxFacialEmotionClassifier = (function(){
 
 exports.MaxFacialEmotionClassifier = MaxFacialEmotionClassifier;
 
-exports.createAnnotatedInput = (imageData, modelData) => {
-    try {
-        let canvas;
-        const img = new Image();
-        img.onload = async () => {
-            canvas = createCanvas(img.width, img.height);
-            const ctx = canvas.getContext('2d');
-            const solidColor = '#1bc6c0';
-            const textColor = '#000';
-            ctx.drawImage(img, 0, 0);
-            const boxesArray = modelData.map((obj, i) => obj.detection_box);
-            boxesArray.forEach((box, i) => {
-                ctx.font = '36px sans-serif';
-                ctx.textBaseline = 'top';
-                ctx.fillStyle = solidColor;
-                ctx.strokeStyle = solidColor;
-                ctx.lineWidth = "3";
-                // BOX GENERATION
-                const yMin = box[0] * img.height;
-                const xMin = box[1] * img.width;
-                const boxHeight = (box[2] - box[0]) * img.height;
-                const boxWidth = (box[3] - box[1]) * img.width;
-                ctx.strokeRect(xMin, yMin, boxWidth, boxHeight);
-                // LABEL GENERATION
-                const confidence = (modelData[i].emotion_predictions[0].probability * 100).toFixed(1) + '%';
-                const label = modelData[i].emotion_predictions[0].label;
-                let text = label + ' : ' + confidence;
-                let tagWidth = ctx.measureText(text).width;
-                if (tagWidth > boxWidth) {
-                    tagWidth = ctx.measureText(label).width;
-                    text = label;
-                }
-                const tHeight = parseInt(ctx.font, 10) * 1.2;
-                ctx.fillRect(xMin, yMin, tagWidth + 3, tHeight);
-                ctx.fillStyle = textColor;
-                ctx.fillText(text, xMin + 2, yMin + 4);
-            })
-        }
-        img.onerror = err => { throw err }
-        img.src = imageData;
-        return canvas.toBuffer();
-    } catch (e) {
-        console.log(`error processing image - ${ e }`);
-        return null;
-    }
+exports.createAnnotatedInput = async (imageData, modelData) => {
+    const {width, height} = sizeOf(imageData);
+    let fontType = getScaledFont(width, 'black');
+    const font = await Jimp.loadFont(fontType);
+    const canvas = await Jimp.read(imageData);
+    const padSize = getPadSize(width);
+    modelData.map(obj => obj.detection_box).forEach((box, i) => {
+        // BOX GENERATION
+        const xMax = box[3] * width;
+        const xMin = box[1] * width;
+        const yMax = box[2] * height;
+        const yMin = box[0] * height;
+        rect(canvas, xMin, yMin, xMax, yMax, padSize, 'cyan');
+        // LABEL GENERATION
+        const text = modelData[i].emotion_predictions[0].label;       
+        const textHeight = Jimp.measureTextHeight(font, text);
+        const xTagMax = Jimp.measureText(font, text) + (padSize*2) + xMin;
+        const yTagMin = yMin - textHeight > 0 ? yMin - textHeight : yMin;
+        rectFill(canvas, xMin, yTagMin, xTagMax, textHeight + yTagMin, padSize, 'cyan');
+        canvas.print(font, xMin + padSize, yTagMin, text);
+    });
+    return canvas.getBufferAsync(Jimp.AUTO);
 }

--- a/facial-emotion-classifier/node.js
+++ b/facial-emotion-classifier/node.js
@@ -56,7 +56,7 @@ module.exports = function (RED) {
                 node.error('Method is not specified.', msg);
                 errorFlag = true;
             }
-            var setData = function (msg, data) {
+            var setData = async function (msg, data) {
                 if (data) {
                     if (data.response) {
                         if (data.response.statusCode) {
@@ -81,7 +81,7 @@ module.exports = function (RED) {
                                 const predictions = data.body.predictions.map(person => person.emotion_predictions[0].label);
                                 msg.payload = predictions[0]
                                 if (node.annotated_input) {
-                                    msg.annotatedInput = lib.createAnnotatedInput(node.inputData, data.body.predictions);
+                                    msg.annotatedInput = await lib.createAnnotatedInput(node.inputData, data.body.predictions);
                                 }
                             } else {
                                 msg.payload = null;
@@ -98,8 +98,8 @@ module.exports = function (RED) {
             };
             if (!errorFlag) {
                 node.status({ fill: 'blue', shape: 'dot', text: 'ModelAssetExchangeServer.status.requesting' });
-                result.then(function (data) {
-                    node.send(setData(msg, data));
+                result.then(async function (data) {
+                    node.send(await setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
                     var message = null;

--- a/facial-recognizer/lib.js
+++ b/facial-recognizer/lib.js
@@ -1,6 +1,8 @@
 /*jshint -W069 */
 
-const { createCanvas, Image } = require('canvas');
+const Jimp = require('jimp');
+const sizeOf = require('buffer-image-size');
+const { rect, rectFill, getScaledFont, getPadSize } = require('../utils');
 
 /**
  * The model detects faces in an input image and then generates an embedding vector for each face. The generated embeddings can be used for downstream tasks such as classification, clustering, verification etc. The model accepts an image as input and returns the bounding box coordinates, probability and embedding vector for each face detected in the image. The model is based on the the FaceNet model.
@@ -146,35 +148,17 @@ ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
 
 exports.ModelAssetExchangeServer = ModelAssetExchangeServer;
 
-
-exports.createAnnotatedInput = (imageData, modelData) => {
-    try {
-        let canvas;
-        const img = new Image();
-        img.onload = async () => {
-            canvas = createCanvas(img.width, img.height);
-            const ctx = canvas.getContext('2d');
-            const solidColor = '#1bc6c0';
-            const textColor = '#000';
-            ctx.drawImage(img, 0, 0)        
-            ctx.fillStyle = solidColor;
-            ctx.strokeStyle = solidColor;
-            ctx.lineWidth = "3";            
-            const boxesArray = modelData.map((obj, i) => obj.detection_box);
-            boxesArray.forEach((box, i) => {
-                // BOX GENERATION
-                const xMin = box[0];
-                const yMin = box[1];
-                const xMax = box[2] - box[0];
-                const yMax = box[3] - box[1];
-                ctx.strokeRect(xMin, yMin, xMax, yMax);
-            })
-        }
-        img.onerror = err => { throw err }
-        img.src = imageData;
-        return canvas.toBuffer();
-    } catch (e) {
-        console.log(`error processing image - ${ e }`);
-        return null;
-    }
+exports.createAnnotatedInput = async (imageData, modelData) => {
+    const {width, height} = sizeOf(imageData);
+    const canvas = await Jimp.read(imageData);
+    const padSize = getPadSize(width);
+    modelData.map(obj => obj.detection_box).forEach((box, i) => {
+        // BOX GENERATION
+        const xMax = box[2];
+        const xMin = box[0];
+        const yMax = box[3];
+        const yMin = box[1];
+        rect(canvas, xMin, yMin, xMax, yMax, padSize, 'cyan');
+    });
+    return canvas.getBufferAsync(Jimp.AUTO);
 }

--- a/facial-recognizer/node.js
+++ b/facial-recognizer/node.js
@@ -53,7 +53,7 @@ module.exports = function (RED) {
                 node.error('Method is not specified.', msg);
                 errorFlag = true;
             }
-            var setData = function (msg, data) {
+            var setData = async function (msg, data) {
                 if (data) {
                     if (data.response) {
                         if (data.response.statusCode) {
@@ -74,7 +74,7 @@ module.exports = function (RED) {
                             if (data.body.predictions && data.body.predictions.length > 0) {
                                 msg.payload = data.body.predictions[0].detection_box;
                                 if (node.annotated_input) {
-                                    msg.annotatedInput = lib.createAnnotatedInput(node.inputData, data.body.predictions);
+                                    msg.annotatedInput = await lib.createAnnotatedInput(node.inputData, data.body.predictions);
                                 }
                             } else {
                                 msg.payload = null;
@@ -91,8 +91,8 @@ module.exports = function (RED) {
             };
             if (!errorFlag) {
                 node.status({ fill: 'blue', shape: 'dot', text: 'ModelAssetExchangeServer.status.requesting' });
-                result.then(function (data) {
-                    node.send(setData(msg, data));
+                result.then(async function (data) {
+                    node.send(await setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
                     var message = null;

--- a/human-pose-estimator/lib.js
+++ b/human-pose-estimator/lib.js
@@ -1,6 +1,8 @@
 /*jshint -W069 */
 
-const { createCanvas, Image } = require('canvas');
+const Jimp = require('jimp');
+const sizeOf = require('buffer-image-size');
+const { rect, rectFill, getScaledFont, getPadSize, drawLine } = require('../utils');
 
 /**
  * This model detects humans and their poses in a given image. The model first detects the humans in the input image and then identifies the body parts, including nose, neck, eyes, shoulders, elbows, wrists, hips, knees, and ankles. Next, each pair of associated body parts is connected by a pose line. The pose lines are assembled into full body poses for each of the humans detected in the image. The model is based on the TF implementation of OpenPose model.
@@ -147,40 +149,22 @@ ModelAssetExchangeServer.prototype.get_metadata = function(parameters){
 
 exports.ModelAssetExchangeServer = ModelAssetExchangeServer;
 
-exports.createAnnotatedInput = (imageData, modelData) => {
-    try {
-        let canvas;
-        const img = new Image();
-        img.onload = async () => {
-            canvas = createCanvas(img.width, img.height);
-            const ctx = canvas.getContext('2d');
-            const solidColor = '#1bc6c0';
-            const textColor = '#000';
-            ctx.drawImage(img, 0, 0);                    
-            const linesArray = modelData.map((obj, i) => obj.pose_lines);
-            linesArray.forEach((skeleton, i) => {
-                skeleton.forEach((lineObj, i) => {
-                    const { line } = lineObj;
-                    ctx.fillStyle = solidColor;
-                    ctx.strokeStyle = solidColor;
-                    ctx.lineWidth = "5";
-                    // LINE GENERATION
-                    const xMin = line[0];
-                    const yMin = line[1];
-                    const xMax = line[2];
-                    const yMax = line[3];
-                    ctx.beginPath();
-                    ctx.moveTo(xMin, yMin);
-                    ctx.lineTo(xMax, yMax);
-                    ctx.stroke();
-                })
-            })
-        }
-        img.onerror = err => { throw err }
-        img.src = imageData;
-        return canvas.toBuffer();
-    } catch (e) {
-        console.log(`error processing image - ${ e }`);
-        return null;
-    }
+exports.createAnnotatedInput = async (imageData, modelData) => {
+    const {width, height} = sizeOf(imageData);
+    let fontType = getScaledFont(width, 'black');
+    const font = await Jimp.loadFont(fontType);
+    const canvas = await Jimp.read(imageData);
+    const padSize = getPadSize(width);
+    modelData.map(obj => obj.pose_lines).forEach((skeleton, i) => {
+        skeleton.forEach((lineObj, i) => {
+            const { line } = lineObj;
+            // LINE GENERATION
+            const xMin = line[0];
+            const yMin = line[1];
+            const xMax = line[2];
+            const yMax = line[3];
+            drawLine(canvas, xMin, yMin, xMax, yMax, padSize, 'cyan'); 
+        });
+    });
+    return canvas.getBufferAsync(Jimp.AUTO);
 }

--- a/human-pose-estimator/lib.js
+++ b/human-pose-estimator/lib.js
@@ -151,13 +151,12 @@ exports.ModelAssetExchangeServer = ModelAssetExchangeServer;
 
 exports.createAnnotatedInput = async (imageData, modelData) => {
     const {width, height} = sizeOf(imageData);
-    let fontType = getScaledFont(width, 'black');
-    const font = await Jimp.loadFont(fontType);
     const canvas = await Jimp.read(imageData);
     const padSize = getPadSize(width);
     modelData.map(obj => obj.pose_lines).forEach((skeleton, i) => {
         skeleton.forEach((lineObj, i) => {
             const { line } = lineObj;
+            //console.log(`${i} ${line}`)
             // LINE GENERATION
             const xMin = line[0];
             const yMin = line[1];

--- a/human-pose-estimator/node.js
+++ b/human-pose-estimator/node.js
@@ -53,7 +53,7 @@ module.exports = function (RED) {
                 node.error('Method is not specified.', msg);
                 errorFlag = true;
             }
-            var setData = function (msg, data) {
+            var setData = async function (msg, data) {
                 if (data) {
                     if (data.response) {
                         if (data.response.statusCode) {
@@ -74,7 +74,7 @@ module.exports = function (RED) {
                             if (data.body.predictions && data.body.predictions.length > 0) {
                                 msg.payload = data.body.predictions[0].body_parts;
                                 if (node.annotated_input) {
-                                    msg.annotatedInput = lib.createAnnotatedInput(node.inputData, data.body.predictions);
+                                    msg.annotatedInput = await lib.createAnnotatedInput(node.inputData, data.body.predictions);
                                 }
                             } else {
                                 msg.payload = null;
@@ -91,8 +91,8 @@ module.exports = function (RED) {
             };
             if (!errorFlag) {
                 node.status({ fill: 'blue', shape: 'dot', text: 'ModelAssetExchangeServer.status.requesting' });
-                result.then(function (data) {
-                    node.send(setData(msg, data));
+                result.then(async function (data) {
+                    node.send(await setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
                     var message = null;

--- a/image-segmenter/lib.js
+++ b/image-segmenter/lib.js
@@ -1,11 +1,6 @@
 /*jshint -W069 */
 
 const Jimp = require('jimp');
-<<<<<<< HEAD
-=======
-const sizeOf = require('buffer-image-size');
-const { rect, rectFill, getScaledFont, getPadSize } = require('../utils');
->>>>>>> ce6559f5e67265672bd6ea4e4e8158e1dd02699b
 
 /**
  * An API for serving models

--- a/image-segmenter/lib.js
+++ b/image-segmenter/lib.js
@@ -1,6 +1,8 @@
 /*jshint -W069 */
 
-const { createCanvas, Image } = require('canvas');
+const Jimp = require('jimp');
+const sizeOf = require('buffer-image-size');
+const { rect, rectFill, getScaledFont, getPadSize } = require('../utils');
 
 /**
  * An API for serving models
@@ -47,7 +49,7 @@ var ModelAssetExchangeServer = (function(){
      * @param {object} form - form data object
      * @param {object} deferred - promise object
      */
-    ModelAssetExchangeServer.prototype.request = function(method, url, parameters, body, headers, queryParameters, form, deferred){
+    ModelAssetExchangeServer.prototype.request = async function(method, url, parameters, body, headers, queryParameters, form, deferred){
         var req = {
             method: method,
             uri: url,
@@ -152,37 +154,24 @@ var ModelAssetExchangeServer = (function(){
 
 exports.ModelAssetExchangeServer = ModelAssetExchangeServer;
 
-exports.createAnnotatedInput = (imageData, modelData) => {
-    try {
-        let canvas;
-        const img = new Image();
-        img.onload = async () => {
-            const { scaledWidth, scaledHeight } = getScaledSize(img.width, img.height);
-            canvas = createCanvas(scaledWidth, scaledHeight);
-            const ctx = canvas.getContext('2d');
-            const flatSegMap = modelData.reduce((a, b) => a.concat(b), []);
-            ctx.drawImage(img, 0, 0, scaledWidth, scaledHeight);
-            const imageData = ctx.getImageData(0, 0, scaledWidth, scaledHeight);
-            const data = imageData.data;
-            let objColor = [0, 0, 0];
-            flatSegMap.forEach((s, i) => {
-                if (s !== OBJ_LIST.indexOf('background')) {
-                    objColor = getColor(s);
-                    data[(i * 4)] = objColor[0]; // red channel
-                    data[(i * 4) + 1] = objColor[1]; // green channel
-                    data[(i * 4) + 2] = objColor[2]; // blue channel
-                    data[(i * 4) + 3] = 200; // alpha
-                }
-            })
-            ctx.putImageData(imageData, 0, 0);
+exports.createAnnotatedInput = async (imageData, modelData) => {
+    const canvas = await Jimp.read(imageData);
+    const {width, height} = sizeOf(imageData);
+    const {scaledWidth, scaledHeight} = getScaledSize(width, height);
+    canvas.scaleToFit(513, 513);
+    const flatSegMap = modelData.reduce((a, b) => a.concat(b), []);
+    const data = canvas.bitmap.data;
+    let objColor = [0, 0, 0];
+    flatSegMap.forEach((s, i) => {
+        if (s !== OBJ_LIST.indexOf('background')) {
+            objColor = getColor(s);
+            data[(i * 4)] = objColor[0]; // red channel
+            data[(i * 4) + 1] = objColor[1]; // green channel
+            data[(i * 4) + 2] = objColor[2]; // blue channel
+            data[(i * 4) + 3] = 200; // alpha
         }
-        img.onerror = err => { throw err }
-        img.src = imageData;
-        return canvas.toBuffer();
-    } catch (e) {
-        console.log(`error processing image - ${ e }`)
-        return null;
-    }
+    })
+    return canvas.getBufferAsync(Jimp.AUTO);
 }
 
 const MAX_SIZE = 513;
@@ -190,12 +179,12 @@ const MAX_SIZE = 513;
 const COLOR_MAP = {
     green: [0, 128, 0],
     red: [255, 0, 0],
-    blue: [0, 0, 255],
+    gray: [192, 192, 192],
     purple: [160, 32, 240],
     pink: [255, 185, 80],
-    teal: [0, 128, 128],
+    teal: [30, 128, 128],
     yellow: [255, 255, 0],
-    gray: [192, 192, 192]
+    cyan: [0, 255, 255]
 };
 const COLOR_LIST = Object.values(COLOR_MAP);
 

--- a/image-segmenter/node.js
+++ b/image-segmenter/node.js
@@ -57,7 +57,7 @@ module.exports = function (RED) {
                 errorFlag = true;
             }
 
-            var setData = function (msg, data) {
+            var setData = async function (msg, data) {
                 if (data) {
                     if (data.response) {
                         if (data.response.statusCode) {
@@ -78,7 +78,7 @@ module.exports = function (RED) {
                             if (data.body !== null && data.body !== undefined) {
                                 msg.payload = data.body.seg_map || "Detection Error";
                                 if (node.annotated_input) {
-                                    msg.annotatedInput = lib.createAnnotatedInput(node.inputData, data.body.seg_map);
+                                    msg.annotatedInput = await lib.createAnnotatedInput(node.inputData, data.body.seg_map);
                                 }
                             } else {
                                 msg.payload = null;
@@ -96,8 +96,8 @@ module.exports = function (RED) {
 
             if (!errorFlag) {
                 node.status({ fill: "blue", shape: "dot", text: "ModelAssetExchangeServer.status.requesting" });
-                result.then(function (data) {
-                    node.send(setData(msg, data));
+                result.then(async function (data) {
+                    node.send(await setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
                     var message = null;

--- a/object-detector/lib.js
+++ b/object-detector/lib.js
@@ -1,6 +1,8 @@
 /*jshint -W069 */
 
-const { createCanvas, Image } = require('canvas');
+const Jimp = require('jimp');
+const sizeOf = require('buffer-image-size');
+const { rect, rectFill, getScaledFont, getPadSize } = require('../utils');
 
 /**
  * This model recognizes the objects present in an image from the 80 different high-level classes of objects in the COCO Dataset. The model consists of a deep convolutional net base model for image feature extraction, together with additional convolutional layers specialized for the task of object detection, that was trained on the COCO data set. The input to the model is an image, and the output is a list of estimated class probabilities for the objects detected in the image. The model is based on the SSD Mobilenet V1 object detection model for TensorFlow.
@@ -181,49 +183,25 @@ var ModelAssetExchangeServer = (function(){
 
 exports.ModelAssetExchangeServer = ModelAssetExchangeServer;
 
-exports.createAnnotatedInput = (imageData, modelData) => {
-    try {
-        let canvas;
-        const img = new Image();
-        img.onload = async () => {
-            canvas = createCanvas(img.width, img.height);
-            const ctx = canvas.getContext('2d');
-            const solidColor = '#1bc6c0';
-            const textColor = '#000';
-            ctx.drawImage(img, 0, 0);
-            const boxesArray = modelData.map((obj, i) => obj.detection_box);
-            boxesArray.forEach((box, i) => {
-                ctx.font = '36px sans-serif';
-                ctx.textBaseline = 'top';
-                ctx.fillStyle = solidColor;
-                ctx.strokeStyle = solidColor;
-                ctx.lineWidth = "3";
-                // BOX GENERATION
-                const yMin = box[0] * img.height;
-                const xMin = box[1] * img.width;
-                const boxHeight = (box[2] - box[0]) * img.height;
-                const boxWidth = (box[3] - box[1]) * img.width;
-                ctx.strokeRect(xMin, yMin, boxWidth, boxHeight);
-                // LABEL GENERATION
-                const confidence = (modelData[i].probability * 100).toFixed(1) + '%';
-                const label = modelData[i].label;
-                const text = label + ' : ' + confidence;
-                const tagWidth = ctx.measureText(text).width;
-                if (tagWidth > boxWidth) {
-                    tagWidth = ctx.measureText(label).width;
-                    text = label;
-                }
-                const tHeight = parseInt(ctx.font, 10) * 1.3;
-                ctx.fillRect(xMin, yMin, tagWidth + 3, tHeight);
-                ctx.fillStyle = textColor;
-                ctx.fillText(text, xMin + 2, yMin + 6);
-            })
-        }
-        img.onerror = err => { throw err }
-        img.src = imageData;
-        return canvas.toBuffer();
-    } catch (e) {
-        console.log(`error processing image - ${ e }`);
-        return null;
-    }
+exports.createAnnotatedInput = async (imageData, modelData) => {
+    const {width, height} = sizeOf(imageData);
+    let fontType = getScaledFont(width, 'black');
+    const font = await Jimp.loadFont(fontType);
+    const canvas = await Jimp.read(imageData);
+    const padSize = getPadSize(width);
+    modelData.map(obj => obj.detection_box).forEach((box, i) => {
+        const xMax = box[3] * width;
+        const xMin = box[1] * width;
+        const yMax = box[2] * height;
+        const yMin = box[0] * height;
+        rect(canvas, xMin, yMin, xMax, yMax, padSize, 'cyan');
+        // LABEL GENERATION
+        const text = modelData[i].label;
+        const textHeight = Jimp.measureTextHeight(font, text);
+        const xTagMax = Jimp.measureText(font, text) + (padSize*2) + xMin;
+        const yTagMin = yMin - textHeight > 0 ? yMin - textHeight : yMin;
+        rectFill(canvas, xMin, yTagMin, xTagMax, textHeight + yTagMin, padSize, 'cyan');
+        canvas.print(font, xMin + padSize, yTagMin, text);
+    });
+    return canvas.getBufferAsync(Jimp.AUTO);
 }

--- a/object-detector/node.js
+++ b/object-detector/node.js
@@ -69,7 +69,7 @@ module.exports = function (RED) {
                 node.error('Method is not specified.', msg);
                 errorFlag = true;
             }
-            var setData = function (msg, data) {
+            var setData = async function (msg, data) {
                 if (data) {
                     if (data.response) {
                         if (data.response.statusCode) {
@@ -94,7 +94,7 @@ module.exports = function (RED) {
                                 msg.payload = data.body.predictions[0].label;
 
                                 if (node.annotated_input) {
-                                    msg.annotatedInput = lib.createAnnotatedInput(node.inputData, data.body.predictions);
+                                    msg.annotatedInput = await lib.createAnnotatedInput(node.inputData, data.body.predictions);
                                 }
 
                             } else {
@@ -112,8 +112,8 @@ module.exports = function (RED) {
             };
             if (!errorFlag) {
                 node.status({ fill: 'blue', shape: 'dot', text: 'ModelAssetExchangeServer.status.requesting' });
-                result.then(function (data) {
-                    node.send(setData(msg, data));
+                result.then(async function (data) {
+                    node.send(await setData(msg, data));
                     node.status({});
                 }).catch(function (error) {
                     var message = null;

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "deep learning"
   ],
   "dependencies": {
-    "canvas": "^2.4.1",
+    "buffer-image-size": "^0.6.4",
     "file-type": "^10.7.1",
+    "jimp": "^0.6.4",
     "q": "1.5.1",
     "request": "2.83.0"
   },

--- a/utils/index.js
+++ b/utils/index.js
@@ -20,21 +20,22 @@ const drawRect = (img, xMin, yMin, xMax, yMax, padSize, color, isFilled) => {
 }
 
 const drawLine = (img, xMin, yMin, xMax, yMax, padSize, color) => {
-  const xLength = xMax - xMin;
-  const yLength = yMax - yMin;
-  for (x of range(xMin, xMax)) {
-    let y = yMin + yLength * (x - xMin) / xLength;
-    img.setPixelColor(Jimp.cssColorToHex(color), x-1, y);
-    img.setPixelColor(Jimp.cssColorToHex(color), x, y);
-    img.setPixelColor(Jimp.cssColorToHex(color), x+1, y);
-
-    img.setPixelColor(Jimp.cssColorToHex(color), x-1, y-1);
-    img.setPixelColor(Jimp.cssColorToHex(color), x, y-1);
-    img.setPixelColor(Jimp.cssColorToHex(color), x+1, y-1);
-
-    img.setPixelColor(Jimp.cssColorToHex(color), x-1, y+1);
-    img.setPixelColor(Jimp.cssColorToHex(color), x, y+1);
-    img.setPixelColor(Jimp.cssColorToHex(color), x+1, y+1);
+  const xLength = Math.abs(xMax - xMin);
+  const yLength = Math.abs(yMax - yMin);
+  const steps = xLength > yLength ? xLength : yLength;
+  const xStep = (xMax - xMin) / steps;
+  const yStep = (yMax - yMin) / steps;
+  let x = xMin;
+  let y = yMin;
+  for (s of range(0, steps)) {
+    x = x + xStep;
+    y = y + yStep;
+    for (i of range(x - padSize, x + padSize)) {
+      img.setPixelColor(Jimp.cssColorToHex(color), i, y);
+    }
+    for (j of range(y - padSize, y + padSize)) {
+      img.setPixelColor(Jimp.cssColorToHex(color), x, j);
+    }  
   }
 }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,76 @@
+const Jimp = require('jimp');
+
+const rect = (img, xMin, yMin, xMax, yMax, padSize, color) => 
+  drawRect(img, xMin, yMin, xMax, yMax, padSize, color, false);
+
+const rectFill = (img, xMin, yMin, xMax, yMax, padSize, color) => 
+  drawRect(img, xMin, yMin, xMax, yMax, padSize, color, true);
+
+const drawRect = (img, xMin, yMin, xMax, yMax, padSize, color, isFilled) => {
+  for (x of range(xMin, xMax)) {
+    for (y of range(yMin, yMax)) { 
+      if (withinRange(y, yMin, padSize) || withinRange(x, xMin, padSize) || 
+          withinRange(y, yMax, padSize) || withinRange(x, xMax, padSize)) {
+        img.setPixelColor(Jimp.cssColorToHex(color), x, y);
+      } else if (isFilled && (y <= (yMax + padSize) && x <= (xMax + padSize))) {
+        img.setPixelColor(Jimp.cssColorToHex(color), x, y);
+      }
+    }
+  }
+}
+
+const drawLine = (img, xMin, yMin, xMax, yMax, padSize, color) => {
+  const xLength = xMax - xMin;
+  const yLength = yMax - yMin;
+  for (x of range(xMin, xMax)) {
+    let y = yMin + yLength * (x - xMin) / xLength;
+    img.setPixelColor(Jimp.cssColorToHex(color), x-1, y);
+    img.setPixelColor(Jimp.cssColorToHex(color), x, y);
+    img.setPixelColor(Jimp.cssColorToHex(color), x+1, y);
+
+    img.setPixelColor(Jimp.cssColorToHex(color), x-1, y-1);
+    img.setPixelColor(Jimp.cssColorToHex(color), x, y-1);
+    img.setPixelColor(Jimp.cssColorToHex(color), x+1, y-1);
+
+    img.setPixelColor(Jimp.cssColorToHex(color), x-1, y+1);
+    img.setPixelColor(Jimp.cssColorToHex(color), x, y+1);
+    img.setPixelColor(Jimp.cssColorToHex(color), x+1, y+1);
+  }
+}
+
+const getScaledFont = (width, color) => {
+  if (width > 1600)
+    return color === 'black' ? Jimp.FONT_SANS_128_BLACK : Jimp.FONT_SANS_128_WHITE;
+  else if (width > 700)
+    return color === 'black' ? Jimp.FONT_SANS_32_BLACK : Jimp.FONT_SANS_32_WHITE;
+  else
+  return color === 'black' ? Jimp.FONT_SANS_16_BLACK : Jimp.FONT_SANS_16_WHITE;
+}
+
+const getPadSize = width => {
+  if (width > 1600)
+    return 7;
+  else if (width > 1000)
+    return 4;
+  else if (width > 700)
+    return 3;
+  else
+    return 2;
+}
+
+const withinRange = (i, line, range) =>
+  (line-range<=i)&&(i<=line+range);
+
+function* range(start, end) {
+  for (let i = start; i <= end; i++) {
+      yield i;
+  }
+}
+
+module.exports = {
+  rect, 
+  rectFill,
+  getScaledFont,
+  getPadSize,
+  drawLine
+};


### PR DESCRIPTION
Fixes #52 by removing native dependencies and uses a pure-JS solution for generating annotated output images. Removes `canvas` and adds `jimp`.
